### PR TITLE
#24 - PKMItemHolderPokemonVersionDetail class Change DTO data type

### DIFF
--- a/PokemonAPI/Classes/Items.swift
+++ b/PokemonAPI/Classes/Items.swift
@@ -92,7 +92,7 @@ open class PKMItemHolderPokemon: Codable, SelfDecodable {
 open class PKMItemHolderPokemonVersionDetail: Codable {
     
     /// How often this Pokémon holds this item in this version
-    open var rarity: String?
+    open var rarity: Int?
     
     /// The version that this item is held in by the Pokémon
     open var version: PKMNamedAPIResource<PKMVersion>?

--- a/PokemonAPI/Classes/Pokemon.swift
+++ b/PokemonAPI/Classes/Pokemon.swift
@@ -651,8 +651,11 @@ open class PKMPokemonSprites: Codable, SelfDecodable {
     /// The female depiction of this Pokémon from the back in battle
     open var backFemale: String?
     
+    
     /// The shiny female depiction of this Pokémon from the back in battle
     open var backShinyFemale: String?
+    
+    open var other:Other?
     
     public static var decoder: JSONDecoder = {
         let decoder = JSONDecoder()

--- a/PokemonAPI/Classes/Pokemon.swift
+++ b/PokemonAPI/Classes/Pokemon.swift
@@ -555,6 +555,77 @@ open class PKMPokemonStat: Codable, SelfDecodable {
     }()
 }
 
+//MARK: - Other
+open class Other: Codable,SelfDecodable {
+    
+    open var dreamWorld: DreamWorld?
+    open var home: Home?
+    open var officialArtwork: OfficialArtwork?
+    open var showdown: Showdown?
+
+    
+    public static var decoder: JSONDecoder = {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        return decoder
+    }()
+}
+
+// MARK: - DreamWorld
+open class DreamWorld: Codable,SelfDecodable {
+    open var frontDefault, frontFemale: String?
+
+    
+    public static var decoder: JSONDecoder = {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        return decoder
+    }()
+}
+
+// MARK: - Home
+open class Home: Codable,SelfDecodable {
+    open var frontDefault: String?
+    open var frontFemale: String?
+    open var frontShiny: String?
+    open var frontShinyFemale: String?
+    
+    public static var decoder: JSONDecoder = {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        return decoder
+    }()
+}
+
+// MARK: - OfficialArtwork
+open class OfficialArtwork: Codable,SelfDecodable {
+    open var frontDefault, frontShiny: String?
+
+    public static var decoder: JSONDecoder = {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        return decoder
+    }()
+}
+
+// MARK: - Showdown
+open class Showdown: Codable, SelfDecodable {
+    open var backDefault: String?
+    open var backFemale: String?
+    open var backShiny: String?
+    open var backShinyFemale: String?
+    open var frontDefault: String?
+    open var frontFemale: String?
+    open var frontShiny: String?
+    open var frontShinyFemale: String?
+
+    public static var decoder: JSONDecoder = {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        return decoder
+    }()
+}
+
 
 /// Pokemon Sprites
 open class PKMPokemonSprites: Codable, SelfDecodable {
@@ -701,6 +772,8 @@ open class PKMPokemonFormSprites: Codable, SelfDecodable {
     
     /// The shiny depiction of this Pokémon form from the back in battle
     open var backShiny: String?
+    
+    open var other:Other?
     
     public static var decoder: JSONDecoder = {
         let decoder = JSONDecoder()

--- a/PokemonAPI/Classes/Pokemon.swift
+++ b/PokemonAPI/Classes/Pokemon.swift
@@ -889,7 +889,7 @@ open class PKMPokemonSpeciesDexEntry: Codable, SelfDecodable {
     open var entryNumber: Int?
     
     /// The Pokédex the referenced Pokémon species can be found in
-    open var name: PKMNamedAPIResource<PKMName>?
+    open var pokedex: PKMNamedAPIResource<PKMName>?
     
     public static var decoder: JSONDecoder = {
         let decoder = JSONDecoder()

--- a/PokemonAPI/Classes/Utilities.swift
+++ b/PokemonAPI/Classes/Utilities.swift
@@ -92,6 +92,7 @@ open class PKMFlavorText: Codable, SelfDecodable {
     
     /// The language this name is in
     open var language: PKMName?
+    
     open var version:PKMVersion?
     
     public static var decoder: JSONDecoder = {

--- a/PokemonAPI/Classes/Utilities.swift
+++ b/PokemonAPI/Classes/Utilities.swift
@@ -92,6 +92,7 @@ open class PKMFlavorText: Codable, SelfDecodable {
     
     /// The language this name is in
     open var language: PKMName?
+    open var version:PKMVersion?
     
     public static var decoder: JSONDecoder = {
         let decoder = JSONDecoder()


### PR DESCRIPTION
Of the data in the class PKMitemHolderPokemonVersionDetail, the "rarity" data actually gives a value of Int form, but the "jsonParsingError" error appears when trying to decode it as string within the package.
I want to contribute after solving this problem Thank you.


> held_Items
```json
"version_details": [
      {
          "rarity": 5,    //this data
          "version": {
              "name": "ruby",
              "url": "https://pokeapi.co/api/v2/version/7/"
          }
      }
]
```

```swift
open class PKMItemHolderPokemonVersionDetail: Codable {
    
    open var rarity: String?    //data is not correct
    
    open var version: PKMNamedAPIResource<PKMVersion>?
}
```



