### PR TITLE
[API] Incorrect API enum used for fetching version

### DIFF
--- a/PokemonAPI/WebServices/GameService.swift
+++ b/PokemonAPI/WebServices/GameService.swift
@@ -471,7 +471,7 @@ extension GameService {
      */
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     public func fetchVersion(_ versionID: Int) async throws -> PKMVersion {
-        try await PKMVersion.decode(from: call(endpoint: API.fetchGenerationByID(versionID)))
+        try await PKMVersion.decode(from: call(endpoint: API.fetchVersionByID(versionID)))
     }
     
     
@@ -482,7 +482,7 @@ extension GameService {
      */
     @available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
     public func fetchVersion(_ versionName: String) async throws -> PKMVersion {
-        try await PKMVersion.decode(from: call(endpoint: API.fetchGenerationByName(versionName)))
+        try await PKMVersion.decode(from: call(endpoint: API.fetchVersionByName(versionName)))
     }
     
     


### PR DESCRIPTION
Currently in version 6.1.1, it is pointing to the incorrect API enum, and therefore incorrect endpoint, when we call `fetchVersion` which is currently using 'Generation'. See below for the incorrect calls.

_This is only in the 'Async Services' of the package, the other areas are correctly using the right endpoint_

**Currently**
```
// MARK: - Async Services

extension GameService {
...
@available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
public func fetchVersion(_ versionID: Int) async throws -> PKMVersion {
    try await PKMVersion.decode(from: call(endpoint: API.fetchGenerationByID(versionID)))
}

@available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)
public func fetchVersion(_ versionName: String) async throws -> PKMVersion {
    try await PKMVersion.decode(from: call(endpoint: API.fetchGenerationByName(versionName)))
}
```