### PR TITLE
[Class] Incorrect class type on Version

### DIFF
--- a/PokemonAPI/Classes/Games.swift
+++ b/PokemonAPI/Classes/Games.swift
@@ -112,7 +112,7 @@ open class PKMVersion: Codable, SelfDecodable {
     open var names: [PKMName]?
     
     /// The version group this version belongs to
-    open var versionGroup: PKMNamedAPIResource<PKMVersion>?
+    open var versionGroup: PKMNamedAPIResource<PKMVersionGroup>?
     
     public static var decoder: JSONDecoder = {
         let decoder = JSONDecoder()


### PR DESCRIPTION
Fixes incorrect class type used for VersionGroup inside Version class.

```
open class PKMVersion: Codable, SelfDecodable {
    
    /// The identifier for this version resource
    open var id: Int?
    
    /// The name for this version resource
    open var name: String?
    
    /// The name of this version listed in different languages
    open var names: [PKMName]?
    
    /// The version group this version belongs to
    open var versionGroup: PKMNamedAPIResource<PKMVersion>? <--- here
    
    public static var decoder: JSONDecoder = {
        let decoder = JSONDecoder()
        decoder.keyDecodingStrategy = .convertFromSnakeCase
        return decoder
    }()
}
```